### PR TITLE
SPI Robustness

### DIFF
--- a/hal/src/sercom/spi.rs
+++ b/hal/src/sercom/spi.rs
@@ -1267,6 +1267,13 @@ where
         self.config.as_mut().regs.disable();
         self.config
     }
+
+    /// Disable and then re-enable the SPI peripheral
+    #[inline]
+    pub fn reset(&mut self) {
+        self.config.as_mut().regs.disable();
+        self.config.as_mut().regs.enable();
+    }
 }
 
 #[cfg(feature = "min-samd51g")]

--- a/hal/src/sercom/spi/impl_ehal_thumbv7em.rs
+++ b/hal/src/sercom/spi/impl_ehal_thumbv7em.rs
@@ -291,15 +291,16 @@ macro_rules! impl_blocking_spi_transfer {
                     let mut to_send = cells.iter();
                     let mut to_recv = cells.iter();
                     while to_recv.len() > 0 {
-                        let flags = self.read_flags_errors()?;
-                        if to_send.len() > 0 && flags.contains(Flags::DRE) {
+                        if to_send.len() > 0 {
+                            while !self.read_flags_errors()?.contains(Flags::DRE) {}
                             let word = match to_send.next() {
                                 Some(cell) => cell.get(),
                                 None => unreachable!(),
                             };
                             self.config.as_mut().regs.write_data(word as u32);
                         }
-                        if to_recv.len() > to_send.len() && flags.contains(Flags::RXC) {
+                        if to_recv.len() > to_send.len() {
+                            while !self.read_flags_errors()?.contains(Flags::RXC) {}
                             let word = self.config.as_mut().regs.read_data() as Word<$Length>;
                             match to_recv.next() {
                                 Some(cell) => cell.set(word),


### PR DESCRIPTION
Implemented SPI transfer mods from here: https://github.com/atsamd-rs/atsamd/issues/657. This prevents write and read loops from getting out of sync and requires one read following every write. Also added a reset function to use in SPI fault recovery (reset flags and clears DATA register).