### PR TITLE
Make debounce clock divider configurable

### DIFF
--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -114,7 +114,12 @@ compile_error!("'usb' is enabled, but USB isn't supported on SAMD11");
 
 #[cfg(all(
     feature = "usb",
-    not(any(feature = "samda1", feature = "samd21", feature = "min-samd51g", feature = "library"))
+    not(any(
+        feature = "samda1",
+        feature = "samd21",
+        feature = "min-samd51g",
+        feature = "library"
+    ))
 ))]
 compile_error!("The 'usb' feature is enabled, but not a chip with USB support");
 

--- a/hal/src/thumbv7em/eic/mod.rs
+++ b/hal/src/thumbv7em/eic/mod.rs
@@ -3,6 +3,49 @@ use crate::pac;
 
 pub mod pin;
 
+/// Divider for the EIC debouncer clock
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum EicDivider {
+    DIV2,
+    DIV4,
+    DIV8,
+    DIV16,
+    DIV32,
+    DIV64,
+    DIV128,
+    DIV256,
+}
+
+impl From<EicDivider> for pac::eic::dprescaler::PRESCALER0_A {
+    fn from(div: EicDivider) -> Self {
+        match div {
+            EicDivider::DIV2 => Self::DIV2,
+            EicDivider::DIV4 => Self::DIV4,
+            EicDivider::DIV8 => Self::DIV8,
+            EicDivider::DIV16 => Self::DIV16,
+            EicDivider::DIV32 => Self::DIV32,
+            EicDivider::DIV64 => Self::DIV64,
+            EicDivider::DIV128 => Self::DIV128,
+            EicDivider::DIV256 => Self::DIV256,
+        }
+    }
+}
+
+impl From<EicDivider> for pac::eic::dprescaler::PRESCALER1_A {
+    fn from(div: EicDivider) -> Self {
+        match div {
+            EicDivider::DIV2 => Self::DIV2,
+            EicDivider::DIV4 => Self::DIV4,
+            EicDivider::DIV8 => Self::DIV8,
+            EicDivider::DIV16 => Self::DIV16,
+            EicDivider::DIV32 => Self::DIV32,
+            EicDivider::DIV64 => Self::DIV64,
+            EicDivider::DIV128 => Self::DIV128,
+            EicDivider::DIV256 => Self::DIV256,
+        }
+    }
+}
+
 /// An External Interrupt Controller which is being configured.
 pub struct ConfigurableEIC {
     eic: pac::EIC,
@@ -13,18 +56,31 @@ impl ConfigurableEIC {
         Self { eic }
     }
 
-    pub fn button_debounce_pins_ulp32k(&mut self, debounce_pins: &[pin::ExternalInterruptID]) {
-        self.button_debounce_pins(debounce_pins, true)
+    pub fn button_debounce_pins_ulp32k(
+        &mut self,
+        debounce_pins: &[pin::ExternalInterruptID],
+        div: EicDivider,
+    ) {
+        self.button_debounce_pins(debounce_pins, true, div)
     }
 
-    pub fn button_debounce_pins_gclk(&mut self, debounce_pins: &[pin::ExternalInterruptID]) {
-        self.button_debounce_pins(debounce_pins, false)
+    pub fn button_debounce_pins_gclk(
+        &mut self,
+        debounce_pins: &[pin::ExternalInterruptID],
+        div: EicDivider,
+    ) {
+        self.button_debounce_pins(debounce_pins, false, div)
     }
 
     /// button_debounce_pins enables debouncing for the
     /// specified pins, with a configuration appropriate
     /// for debouncing physical buttons.
-    fn button_debounce_pins(&mut self, debounce_pins: &[pin::ExternalInterruptID], ulp32k: bool) {
+    fn button_debounce_pins(
+        &mut self,
+        debounce_pins: &[pin::ExternalInterruptID],
+        ulp32k: bool,
+        div: EicDivider,
+    ) {
         self.eic.dprescaler.modify(|_, w| {
             if ulp32k {
                 w.tickon().set_bit()
@@ -33,8 +89,8 @@ impl ConfigurableEIC {
             }
             .states0().set_bit()    // Require 7 0 samples to see a falling edge.
             .states1().set_bit()    // Require 7 1 samples to see a rising edge.
-            .prescaler0().div16()
-            .prescaler1().div16()
+            .prescaler0().variant(div.into())
+            .prescaler1().variant(div.into())
         });
 
         let mut debounceen: u32 = 0;
@@ -116,4 +172,3 @@ impl OptionallyConfigurableEIC for EIC {
         &self.eic
     }
 }
-


### PR DESCRIPTION
https://vitalbio.atlassian.net/browse/PROD-2510

Make debounce clock divider configurable. This enables longer debounce intervals for handling noisier inputs, such as the support pack detection switch.