### PR TITLE
Changes for new IA

### DIFF
--- a/hal/src/thumbv7em/adc.rs
+++ b/hal/src/thumbv7em/adc.rs
@@ -47,6 +47,10 @@ macro_rules! adc_hal {
     ($($ADC:ident: ($init:ident, $clock:ident, $apmask:ident, $apbits:ident, $compcal:ident, $refcal:ident, $r2rcal:ident),)+) => {
         $(
 impl Adc<$ADC> {
+    /// Create new ADC
+    ///
+    /// Note that the frequency parameter indicates the desired ADC clock frequency, not the
+    /// sampling frequency, which depends on many parameters.
     pub fn $init<F: Into<Hertz>>(
         clock: &clock::$clock,
         freq: F,
@@ -62,19 +66,8 @@ impl Adc<$ADC> {
 
         // Find best prescaler to get close to target freq
         let freq = freq.into();
-        let sample_ticks = 5 + 12; // 5 ticks for sample time + 1 tick for each of 12 bits
-        let num_samples = 1u32 << samples as u32;
-        let ticks: u32 = clock.freq().0 / freq.0.max(1) / sample_ticks / num_samples;
-        let divider: u32 = {
-            let next_pow = ticks.next_power_of_two();
-            let prev_pow = (ticks >> 1).next_power_of_two();
-            if next_pow - ticks < ticks - prev_pow {
-                next_pow
-            }
-            else {
-                prev_pow
-            }
-        };
+        let ticks: u32 = clock.freq().0 / freq.0.max(1);
+        let divider = (ticks.max(1)).next_power_of_two();
         adc.ctrla.modify(|_, w| w.enable().clear_bit());
         adc.ctrla.modify(|_, w| {
             match divider {
@@ -91,23 +84,22 @@ impl Adc<$ADC> {
             }
         });
 
-        adc.ctrlb.modify(|_, w| w.ressel()._12bit());
+        adc.ctrlb.modify(|_, w| w.ressel().variant(resolution));
         while adc.syncbusy.read().ctrlb().bit_is_set() {}
         adc.sampctrl.modify(|_, w| unsafe {w.samplen().bits(sample_length)}); // sample length
         while adc.syncbusy.read().sampctrl().bit_is_set() {}
         adc.inputctrl.modify(|_, w| w.muxneg().gnd()); // No negative input (internal gnd)
         while adc.syncbusy.read().inputctrl().bit_is_set() {}
 
-        adc.calib.write(|w| unsafe {
+        let mut newadc = Self { adc };
+        newadc.samples(samples);
+        newadc.reference(adc0::refctrl::REFSEL_A::INTVCC1);
+
+        newadc.adc.calib.write(|w| unsafe {
             w.biascomp().bits(calibration::$compcal());
             w.biasrefbuf().bits(calibration::$refcal());
             w.biasr2r().bits(calibration::$r2rcal())
         });
-
-        let mut newadc = Self { adc };
-        newadc.samples(samples);
-        newadc.resolution(resolution);
-        newadc.reference(adc0::refctrl::REFSEL_A::INTVCC1);
 
         newadc
     }

--- a/hal/src/thumbv7em/adc.rs
+++ b/hal/src/thumbv7em/adc.rs
@@ -59,6 +59,7 @@ impl Adc<$ADC> {
         samples: SampleRate,
         resolution: Resolution,
         sample_length: u8,
+        reference: Reference,
     ) -> Self {
         mclk.$apmask.modify(|_, w| w.$apbits().set_bit());
         adc.ctrla.write(|w| w.swrst().set_bit());
@@ -93,7 +94,7 @@ impl Adc<$ADC> {
 
         let mut newadc = Self { adc };
         newadc.samples(samples);
-        newadc.reference(adc0::refctrl::REFSEL_A::INTVCC1);
+        newadc.reference(reference);
 
         newadc.adc.calib.write(|w| unsafe {
             w.biascomp().bits(calibration::$compcal());

--- a/hal/src/thumbv7em/adc.rs
+++ b/hal/src/thumbv7em/adc.rs
@@ -160,13 +160,15 @@ impl Adc<$ADC> {
         while self.adc.syncbusy.read().ctrlb().bit_is_set() {}
     }
 
-    fn power_up(&mut self) {
+    // Enable the ADC
+    pub fn power_up(&mut self) {
         while self.adc.syncbusy.read().enable().bit_is_set() {}
         self.adc.ctrla.modify(|_, w| w.enable().set_bit());
         while self.adc.syncbusy.read().enable().bit_is_set() {}
     }
 
-    fn power_down(&mut self) {
+    // Disable the ADC
+    pub fn power_down(&mut self) {
         while self.adc.syncbusy.read().enable().bit_is_set() {}
         self.adc.ctrla.modify(|_, w| w.enable().clear_bit());
         while self.adc.syncbusy.read().enable().bit_is_set() {}
@@ -218,12 +220,12 @@ impl Adc<$ADC> {
         }
     }
 
-    /// Sets the mux to a particular pin. The pin mux is enabled-protected,
-    /// so must be called while the peripheral is disabled.
+    /// Sets the mux to a particular pin
     fn mux<PIN: Channel<$ADC, ID=u8>>(&mut self, _pin: &mut PIN) {
         let chan = PIN::channel();
         while self.adc.syncbusy.read().inputctrl().bit_is_set() {}
         self.adc.inputctrl.modify(|_, w| w.muxpos().bits(chan));
+        while self.adc.syncbusy.read().inputctrl().bit_is_set() {}
     }
 }
 
@@ -232,7 +234,6 @@ impl ConversionMode<$ADC> for SingleConversion  {
     }
     fn on_complete(adc: &mut Adc<$ADC>) {
         adc.disable_interrupts();
-        adc.power_down();
     }
     fn on_stop(_adc: &mut Adc<$ADC>) {
     }
@@ -246,7 +247,6 @@ impl ConversionMode<$ADC> for FreeRunning {
     }
     fn on_stop(adc: &mut Adc<$ADC>) {
         adc.disable_interrupts();
-        adc.power_down();
         adc.disable_freerunning();
     }
 }
@@ -266,7 +266,6 @@ impl<C> InterruptAdc<$ADC, C>
     /// Starts a conversion sampling the specified pin.
     pub fn start_conversion<PIN: Channel<$ADC, ID=u8>>(&mut self, pin: &mut PIN) {
         self.adc.mux(pin);
-        self.adc.power_up();
         C::on_start(&mut self.adc);
         self.adc.enable_interrupts();
         self.adc.start_conversion();
@@ -297,9 +296,7 @@ where
 
    fn read(&mut self, pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
         self.mux(pin);
-        self.power_up();
         let result = self.synchronous_convert();
-        self.power_down();
         Ok(result.into())
    }
 }

--- a/hal/src/thumbv7em/adc.rs
+++ b/hal/src/thumbv7em/adc.rs
@@ -300,7 +300,7 @@ where
    WORD: From<u16>,
    PIN: Channel<$ADC, ID=u8>,
 {
-   type Error = ();
+   type Error = core::convert::Infallible;
 
    fn read(&mut self, pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
         self.mux(pin);

--- a/hal/src/thumbv7em/adc.rs
+++ b/hal/src/thumbv7em/adc.rs
@@ -43,6 +43,18 @@ pub trait ConversionMode<ADC> {
 pub struct SingleConversion;
 pub struct FreeRunning;
 
+/// Combination of sampling rate and resolution parameters
+#[derive(Debug, Clone, Copy)]
+pub enum SampleResolution {
+    /// For single sampling, we can set the resolution freely
+    Single(Resolution),
+    /// When averaging multiple samples, resolution needs to be set to 16 bits and the result will
+    /// always be 12 bits. According to the datasheet, it's most likely that you can't go below 12
+    /// bits of resolution when averaging
+    Average(SampleRate),
+    // Support other configurations in the future, such as oversampling
+}
+
 macro_rules! adc_hal {
     ($($ADC:ident: ($init:ident, $clock:ident, $apmask:ident, $apbits:ident, $compcal:ident, $refcal:ident, $r2rcal:ident),)+) => {
         $(
@@ -56,8 +68,7 @@ impl Adc<$ADC> {
         freq: F,
         adc: $ADC,
         mclk: &mut MCLK,
-        samples: SampleRate,
-        resolution: Resolution,
+        sample_resolution: SampleResolution,
         sample_length: u8,
         reference: Reference,
     ) -> Self {
@@ -85,15 +96,13 @@ impl Adc<$ADC> {
             }
         });
 
-        adc.ctrlb.modify(|_, w| w.ressel().variant(resolution));
-        while adc.syncbusy.read().ctrlb().bit_is_set() {}
         adc.sampctrl.modify(|_, w| unsafe {w.samplen().bits(sample_length)}); // sample length
         while adc.syncbusy.read().sampctrl().bit_is_set() {}
         adc.inputctrl.modify(|_, w| w.muxneg().gnd()); // No negative input (internal gnd)
         while adc.syncbusy.read().inputctrl().bit_is_set() {}
 
         let mut newadc = Self { adc };
-        newadc.samples(samples);
+        newadc.sample_resolution(sample_resolution);
         newadc.reference(reference);
 
         newadc.adc.calib.write(|w| unsafe {
@@ -105,9 +114,18 @@ impl Adc<$ADC> {
         newadc
     }
 
-    /// Set the sample rate
-    pub fn samples(&mut self, samples: SampleRate) {
+    /// Set the sample rate and resolution
+    pub fn sample_resolution(&mut self, sample_resolution: SampleResolution) {
         use adc0::avgctrl::SAMPLENUM_A;
+
+        let (samples, resolution) = match sample_resolution {
+            SampleResolution::Single(resolution) => (SAMPLENUM_A::_1, resolution),
+            SampleResolution::Average(samples) => (samples, Resolution::_16BIT),
+        };
+
+        self.adc.ctrlb.modify(|_, w| w.ressel().variant(resolution));
+        while self.adc.syncbusy.read().ctrlb().bit_is_set() {}
+
         self.adc.avgctrl.modify(|_, w| {
             w.samplenum().variant(samples);
             unsafe {
@@ -125,31 +143,12 @@ impl Adc<$ADC> {
         while self.adc.syncbusy.read().avgctrl().bit_is_set() {}
     }
 
-    /// Set the sample rate
-    pub fn division_coefficient(&mut self, coefficient: u8) {
-        let coefficient = if coefficient > 4 { 4 } else { coefficient }; // Can't be greater than 4
-        self.adc.avgctrl.modify(|_, w| {
-            unsafe {
-                w.adjres().bits(coefficient)
-            }
-        });
-        while self.adc.syncbusy.read().avgctrl().bit_is_set() {}
-    }
-
     /// Set the voltage reference
     pub fn reference(&mut self, reference: Reference) {
         self.adc
             .refctrl
             .modify(|_, w| w.refsel().variant(reference));
         while self.adc.syncbusy.read().refctrl().bit_is_set() {}
-    }
-
-    /// Set the input resolution
-    pub fn resolution(&mut self, resolution: Resolution) {
-        self.adc
-            .ctrlb
-            .modify(|_, w| w.ressel().variant(resolution));
-        while self.adc.syncbusy.read().ctrlb().bit_is_set() {}
     }
 
     // Enable the ADC

--- a/hal/src/thumbv7em/adc.rs
+++ b/hal/src/thumbv7em/adc.rs
@@ -144,14 +144,6 @@ impl Adc<$ADC> {
         while self.adc.syncbusy.read().refctrl().bit_is_set() {}
     }
 
-    /// Set the prescaler for adjusting the clock relative to the system clock
-    pub fn prescaler(&mut self, prescaler: Prescaler) {
-        self.adc
-            .ctrla
-            .modify(|_, w| w.prescaler().variant(prescaler));
-        // Note there is no syncbusy for ctrla
-    }
-
     /// Set the input resolution
     pub fn resolution(&mut self, resolution: Resolution) {
         self.adc

--- a/hal/src/thumbv7em/adc.rs
+++ b/hal/src/thumbv7em/adc.rs
@@ -54,6 +54,7 @@ impl Adc<$ADC> {
         mclk: &mut MCLK,
         samples: SampleRate,
         resolution: Resolution,
+        sample_length: u8,
     ) -> Self {
         mclk.$apmask.modify(|_, w| w.$apbits().set_bit());
         adc.ctrla.write(|w| w.swrst().set_bit());
@@ -92,7 +93,7 @@ impl Adc<$ADC> {
 
         adc.ctrlb.modify(|_, w| w.ressel()._12bit());
         while adc.syncbusy.read().ctrlb().bit_is_set() {}
-        adc.sampctrl.modify(|_, w| unsafe {w.samplen().bits(5)}); // sample length
+        adc.sampctrl.modify(|_, w| unsafe {w.samplen().bits(sample_length)}); // sample length
         while adc.syncbusy.read().sampctrl().bit_is_set() {}
         adc.inputctrl.modify(|_, w| w.muxneg().gnd()); // No negative input (internal gnd)
         while adc.syncbusy.read().inputctrl().bit_is_set() {}

--- a/hal/src/thumbv7em/pwm.rs
+++ b/hal/src/thumbv7em/pwm.rs
@@ -3,7 +3,7 @@
 use crate::clock;
 use crate::ehal::{Pwm, PwmPin};
 use crate::gpio::*;
-use crate::gpio::{AlternateE, AnyPin, Pin};
+use crate::gpio::{AlternateE, Pin};
 use crate::time::Hertz;
 use crate::timer_params::TimerParams;
 
@@ -18,24 +18,8 @@ use crate::pac::{TC6, TC7};
 
 // Timer/Counter (TCx)
 
-/// This is a major syntax hack.
-///
-/// The previous Pinout types were enums that took specific v1::Pin types. As a
-/// result, there was no way to make that implementation simultaneously
-/// compatible with both v1::Pin and Pin.
-///
-/// BUT, the enum variant syntax is the same as the namespaced function syntax.
-/// I converted the enums to structs, and I created constructor methods with the
-/// same names as the previous enum variants. By constructing Pinout types with
-/// functions rather than enum variants, you can make it generic over v1::Pin
-/// and Pin types.
-///
-/// This is (mostly) backwards compatible with the current syntax, and all the
-/// existing calls compile. The only incompatible change is the requirement of
-/// type parameters on the Pwm types. Most of the type, the type parameters can
-/// be inferred, so this is mostly backwards compatible as well. But there were
-/// one or two instances where I had to add explicit type parameters to existing
-/// BSP code.
+/// Pinout type must be created from the "correct" pin type, and the user is responsible for
+/// converting the pin type properly
 macro_rules! impl_tc_pinout {
     (
         $Type:ident: [ $(
@@ -43,17 +27,37 @@ macro_rules! impl_tc_pinout {
             ($func: ident, $Id: ident)
         ),+ ]
     ) => {
-        pub struct $Type<I: PinId> {
-            _pin: Pin<I, AlternateE>,
-        }
+        pub struct $Type(());
 
         $(
             $( #[$attr] )?
-            impl $Type<$Id> {
+            impl $Type {
                 #[inline]
-                pub fn $func(pin: impl AnyPin<Id = $Id>) -> Self {
-                    let _pin = pin.into().into_alternate();
-                    Self { _pin }
+                pub fn $func(_pin: Pin<$Id, AlternateE>) -> Self {
+                    Self(())
+                }
+            }
+        )+
+    };
+}
+
+/// Pinout type must be created from the "correct" pin type, and the user is responsible for
+/// converting the pin type properly
+macro_rules! impl_tcc_pinout {
+    (
+        $Type:ident: [ $(
+            $( #[$attr:meta] )?
+            ($func: ident, $Id: ident, $Mode:ident)
+        ),+ ]
+    ) => {
+        pub struct $Type(());
+
+        $(
+            $( #[$attr] )?
+            impl $Type {
+                #[inline]
+                pub fn $func(_pin: Pin<$Id, $Mode>) -> Self {
+                    Self(())
                 }
             }
         )+
@@ -83,21 +87,19 @@ macro_rules! pwm {
     ($($TYPE:ident: ($TC:ident, $pinout:ident, $clock:ident, $apmask:ident, $apbits:ident, $wrapper:ident),)+) => {
         $(
 
-pub struct $TYPE<I: PinId> {
+pub struct $TYPE {
     /// The frequency of the attached clock, not the period of the pwm.
     /// Used to calculate the period of the pwm.
     clock_freq: Hertz,
     tc: $TC,
-    #[allow(dead_code)]
-    pinout: $pinout<I>,
 }
 
-impl<I: PinId> $TYPE<I> {
+impl $TYPE {
     pub fn new<F: Into<Hertz>> (
         clock: &clock::$clock,
         freq: F,
         tc: $TC,
-        pinout: $pinout<I>,
+        _pinout: $pinout,
         mclk: &mut MCLK,
     ) -> Self {
         let freq = freq.into();
@@ -132,7 +134,6 @@ impl<I: PinId> $TYPE<I> {
         Self {
             clock_freq: clock.freq(),
             tc,
-            pinout,
         }
     }
 
@@ -170,7 +171,7 @@ impl<I: PinId> $TYPE<I> {
     }
 }
 
-impl<I: PinId> PwmPin for $TYPE<I> {
+impl PwmPin for $TYPE {
     type Duty = u16;
 
     fn disable(&mut self) {
@@ -261,21 +262,21 @@ macro_rules! pwm_tc {
     ($($TYPE:ident: ($TC:ident, $pinout:ident, $clock:ident, $apmask:ident, $apbits:ident, $wrapper:ident),)+) => {
         $(
 
-pub struct $TYPE<I: PinId> {
+pub struct $TYPE {
     /// The frequency of the attached clock, not the period of the pwm.
     /// Used to calculate the period of the pwm.
     clock_freq: Hertz,
     tc: $TC,
     #[allow(dead_code)]
-    pinout: $pinout<I>,
+    pinout: $pinout,
 }
 
-impl<I: PinId> $TYPE<I> {
+impl $TYPE {
     pub fn new (
         clock: &clock::$clock,
         clock_divider: TcClockPrescaler,
         tc: $TC,
-        pinout: $pinout<I>,
+        pinout: $pinout,
         mclk: &mut MCLK,
     ) -> Self {
         let count = tc.count16();
@@ -306,7 +307,7 @@ impl<I: PinId> $TYPE<I> {
     }
 }
 
-impl<I: PinId> Pwm for $TYPE<I> {
+impl Pwm for $TYPE {
     type Channel = Channel;
     type Time = Hertz;
     type Duty = u16;
@@ -384,48 +385,6 @@ pub enum Channel {
     _5,
     _6,
     _7,
-}
-
-/// This is a major syntax hack.
-///
-/// The previous Pinout types were enums that took specific v1::Pin types. As a
-/// result, there was no way to make that implementation simultaneously
-/// compatible with both v1::Pin and Pin.
-///
-/// BUT, the enum variant syntax is the same as the namespaced function syntax.
-/// I converted the enums to structs, and I created constructor methods with the
-/// same names as the previous enum variants. By constructing Pinout types with
-/// functions rather than enum variants, you can make it generic over v1::Pin
-/// and Pin types.
-///
-/// This is (mostly) backwards compatible with the current syntax, and all the
-/// existing calls compile. The only incompatible change is the requirement of
-/// type parameters on the Pwm types. Most of the type, the type parameters can
-/// be inferred, so this is mostly backwards compatible as well. But there were
-/// one or two instances where I had to add explicit type parameters to existing
-/// BSP code.
-macro_rules! impl_tcc_pinout {
-    (
-        $Type:ident: [ $(
-            $( #[$attr:meta] )?
-            ($func: ident, $Id: ident, $Mode:ident)
-        ),+ ]
-    ) => {
-        pub struct $Type<I: PinId, M: PinMode> {
-            _pin: Pin<I, M>,
-        }
-
-        $(
-            $( #[$attr] )?
-            impl $Type<$Id, $Mode> {
-                #[inline]
-                pub fn $func(pin: impl AnyPin<Id = $Id>) -> Self {
-                    let _pin = pin.into().into_alternate();
-                    Self { _pin }
-                }
-            }
-        )+
-    };
 }
 
 impl_tcc_pinout!(TCC0Pinout: [
@@ -585,23 +544,23 @@ macro_rules! pwm_tcc {
     ($($TYPE:ident: ($TCC:ident, $pinout:ident, $clock:ident, $apmask:ident, $apbits:ident, $wrapper:ident),)+) => {
         $(
 
-pub struct $TYPE<I: PinId, M: PinMode> {
+pub struct $TYPE {
     /// The frequency of the attached clock, not the period of the pwm.
     /// Used to calculate the period of the pwm.
     clock_freq: Hertz,
     tcc: $TCC,
-    #[allow(dead_code)]
-    pinout: $pinout<I, M>,
 }
 
-impl<I: PinId, M: PinMode> $TYPE<I, M> {
-    pub fn new<F: Into<Hertz>> (
+impl $TYPE {
+    /// TCC can take multiple pinouts for multiple channels
+    pub fn new<F: Into<Hertz>, const N: usize> (
         clock: &clock::$clock,
         freq: F,
         tcc: $TCC,
-        pinout: $pinout<I, M>,
+        _pinouts: [$pinout; N],
         mclk: &mut MCLK,
     ) -> Self {
+        const { assert!(N > 0, "must have at least one pinout"); }
         let freq = freq.into();
         {
             let params = TimerParams::new(freq, clock.freq().0);
@@ -634,7 +593,6 @@ impl<I: PinId, M: PinMode> $TYPE<I, M> {
         Self {
             clock_freq: clock.freq(),
             tcc,
-            pinout,
         }
     }
 
@@ -663,7 +621,7 @@ impl<I: PinId, M: PinMode> $TYPE<I, M> {
     }
 }
 
-impl<I: PinId, M: PinMode> Pwm for $TYPE<I, M> {
+impl Pwm for $TYPE {
     type Channel = Channel;
     type Time = Hertz;
     type Duty = u32;


### PR DESCRIPTION
# Summary
Use multiple pinouts for PWM and don't convert pinouts to alternate function, since we already do that in the BSP.